### PR TITLE
Enhance RMK action with new commands and input options. Add 'release_…

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Controlled by the `rmk_command` input:
 |---------------------|----------------------------------------------|
 | `provision`         | Provision a cluster and sync releases        |
 | `destroy`           | Tear down a cluster (with CAPI safety logic) |
-| `release_sync`      | Apply release definitions                    |
+| `release_destroy`   | Destroy releases by selector                 |
+| `release_sync`      | Sync releases by selector                    |
 | `release_update`    | Update release version/tag for a repository  |
 | `project_update`    | Patch dependency version in `project.yaml`   |
 | `helmfile_validate` | Validate Helmfile templates                  |

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: Action for provisioning and destroying clusters, updating and synch
 
 inputs:
   allowed_environments:
-    description: Allowed environments participating in releases for RMK commands "destroy", "helmfile_validate", "project_update", "provision", "release_sync", "release_update".
+    description: Allowed environments participating in releases for RMK commands.
     required: true
     default: develop,staging
   cluster_provider_credentials:
@@ -141,8 +141,22 @@ inputs:
     required: true
     default: aws
   rmk_command:
-    description: Command to run CD in RMK. Allowed values are "destroy", "helmfile_validate", "project_update", "provision", "release_sync", "release_update".
+    description: RMK command to run. Allowed values are "destroy", "helmfile_validate", "project_update", "provision", "release_destroy", "release_sync", "release_update".
     required: true
+  rmk_destroy_labels:
+    description: |
+      List of labels when running release destroy in RMK (only if rmk_command=destroy|release_destroy).
+      Labels are not used if rmk_destroy_skip_release_destroy=true and rmk_command=destroy.
+      Example:
+      rmk_destroy_labels: |
+        scope=kodjin
+        app=fhir-server-api
+    required: false
+    default: ""
+  rmk_destroy_skip_release_destroy:
+    description: Whether to skip release destroy when running destroy in RMK (only if rmk_command=destroy).
+    required: false
+    default: false
   rmk_download_url:
     description: |
       URL of the download script for RMK installation.
@@ -156,6 +170,10 @@ inputs:
   rmk_project_dependency_version:
     description: Dependency version. Allows using a set of RMK commands to project dependency version update to project.yaml file (only if rmk_command=project_update).
     required: false
+  rmk_provision_skip_release_sync:
+    description: Whether to skip release sync when running provision in RMK (only if rmk_command=provision).
+    required: false
+    default: false
   rmk_release_repository_full_name:
     description: Image repository full name of application (includes registry URL and repository_name, only if rmk_command=release_update).
     required: false
@@ -186,6 +204,7 @@ inputs:
   rmk_sync_labels:
     description: |
       List of labels when running sync in RMK (only if rmk_command=provision|release_sync).
+      Labels are not used if rmk_provision_skip_release_sync=true and rmk_command=provision.
       Example:
       rmk_sync_labels: |
         scope=kodjin
@@ -247,9 +266,12 @@ runs:
         INPUT_GITHUB_TOKEN_REPO_FULL_ACCESS: ${{ inputs.github_token_repo_full_access }}
         INPUT_RMK_CLUSTER_PROVIDER: ${{ inputs.rmk_cluster_provider }}
         INPUT_RMK_COMMAND: ${{ inputs.rmk_command }}
+        INPUT_RMK_DESTROY_LABELS: ${{ inputs.rmk_destroy_labels }}
+        INPUT_RMK_DESTROY_SKIP_RELEASE_DESTROY: ${{ inputs.rmk_destroy_skip_release_destroy }}
         INPUT_RMK_DOWNLOAD_URL: ${{ inputs.rmk_download_url }}
         INPUT_RMK_PROJECT_DEPENDENCY_NAME: ${{ inputs.rmk_project_dependency_name }}
         INPUT_RMK_PROJECT_DEPENDENCY_VERSION: ${{ inputs.rmk_project_dependency_version }}
+        INPUT_RMK_PROVISION_SKIP_RELEASE_SYNC: ${{ inputs.rmk_provision_skip_release_sync }}
         INPUT_RMK_RELEASE_REPOSITORY_FULL_NAME: ${{ inputs.rmk_release_repository_full_name }}
         INPUT_RMK_RELEASE_VERSION: ${{ inputs.rmk_release_version }}
         INPUT_RMK_SLACK_CHANNEL: ${{ inputs.rmk_slack_channel }}

--- a/src/actions/actions.py
+++ b/src/actions/actions.py
@@ -41,8 +41,11 @@ class DestroyCommand(BaseCommand):
 
         print(f"Destroying cluster for branch {self.github_context.ref_name}, environment {self.environment}")
         try:
-            self.run_command("rmk release list")
-            self.run_command("rmk release destroy")
+            if self.args.rmk_destroy_skip_release_destroy != "true":
+                destroy_labels = self.args.rmk_destroy_labels
+                flags_labels = "".join([f" --selector {label}" for label in destroy_labels.split()])
+                self.run_command("rmk release list")
+                self.run_command(f"rmk release destroy {flags_labels}")
             self.run_command("rmk cluster capi create")
             self.run_command("rmk cluster capi provision")
             self.run_command("rmk cluster capi destroy")
@@ -82,14 +85,15 @@ class ProvisionCommand(BaseCommand):
                               "Failure", slack_message, tenant=self.tenant, slack_message_log_output=False)
             raise ValueError(f"{err}")
 
-        try:
-            sync_labels = self.args.rmk_sync_labels
-            flags_labels = "".join([f" --selector {label}" for label in sync_labels.split()])
-            self.run_command(f"rmk release sync {flags_labels}")
-        except Exception as err:
-            self.notify_slack(self.github_context, self.args,
-                              "Failure", f"{err}", tenant=self.tenant)
-            raise ValueError(f"{err}")
+        if self.args.rmk_provision_skip_release_sync != "true":
+            try:
+                sync_labels = self.args.rmk_sync_labels
+                flags_labels = "".join([f" --selector {label}" for label in sync_labels.split()])
+                self.run_command(f"rmk release sync {flags_labels}")
+            except Exception as err:
+                self.notify_slack(self.github_context, self.args,
+                                  "Failure", f"{err}", tenant=self.tenant)
+                raise ValueError(f"{err}")
 
         self.notify_slack(self.github_context, self.args,
                           "Success", "Cluster has been provisioned", tenant=self.tenant)
@@ -192,6 +196,22 @@ class ReleaseSyncCommand(BaseCommand):
             raise ValueError(f"{err}")
 
 
+class ReleaseDestroyCommand(BaseCommand):
+    def __init__(self, github_context: GitHubContext, args: Namespace, environment: str, tenant: str):
+        super().__init__(environment)
+        self.github_context = github_context
+        self.args = args
+        self.tenant = tenant
+
+    def run(self):
+        try:
+            destroy_labels = self.args.rmk_destroy_labels
+            flags_labels = "".join([f" --selector {label}" for label in destroy_labels.split()])
+            self.run_command(f"rmk release destroy {flags_labels}")
+        except Exception as err:
+            raise ValueError(f"{err}")
+
+
 class ReleaseUpdateCommand(BaseCommand):
     def __init__(self, github_context: GitHubContext, args: Namespace, environment: str, tenant: str):
         super().__init__(environment)
@@ -289,6 +309,9 @@ class RMKCLIExecutor(CMDInterface):
                 GitHubOutput().output_dict(data_output)
             case "release_sync":
                 ReleaseSyncCommand(self.github_context, self.args, self.environment, self.tenant).run()
+                GitHubOutput().output_dict(data_output)
+            case "release_destroy":
+                ReleaseDestroyCommand(self.github_context, self.args, self.environment, self.tenant).run()
                 GitHubOutput().output_dict(data_output)
             case "release_update":
                 extra_output = {

--- a/src/input_output/input.py
+++ b/src/input_output/input.py
@@ -31,6 +31,14 @@ class GitLabflowCDArgumentParser(ArgumentParser):
                                  action=self.EnvDefault, envvar="INPUT_RMK_COMMAND",
                                  type=str, required=False)
 
+        self.parser.add_argument("--rmk-destroy-labels",
+                                 action=self.EnvDefault, envvar="INPUT_RMK_DESTROY_LABELS",
+                                 type=str, required=False)
+
+        self.parser.add_argument("--rmk-destroy-skip-release-destroy",
+                                 action=self.EnvDefault, envvar="INPUT_RMK_DESTROY_SKIP_RELEASE_DESTROY",
+                                 type=str, required=False)
+
         self.parser.add_argument("--rmk-download-url",
                                  action=self.EnvDefault, envvar="INPUT_RMK_DOWNLOAD_URL",
                                  type=str, default='https://edenlabllc-rmk.s3.eu-north-1.amazonaws.com/rmk/s3-installer')
@@ -41,6 +49,10 @@ class GitLabflowCDArgumentParser(ArgumentParser):
 
         self.parser.add_argument("--rmk-project-dependency-version",
                                  action=self.EnvDefault, envvar="INPUT_RMK_PROJECT_DEPENDENCY_VERSION",
+                                 type=str, required=False)
+
+        self.parser.add_argument("--rmk-provision-skip-release-sync",
+                                 action=self.EnvDefault, envvar="INPUT_RMK_PROVISION_SKIP_RELEASE_SYNC",
                                  type=str, required=False)
 
         self.parser.add_argument("--rmk-release-repository-full-name",


### PR DESCRIPTION
…destroy' command and associated labels for destruction. Introduce options to skip release destruction and sync during provision. Update documentation and input parsing accordingly.